### PR TITLE
Add effect disallowed dependencies to exhaustive deps eslint rule

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -198,20 +198,21 @@ export default {
       // Disallowed dependencies are specified in the eslint rule config
       // import { moduleImport } from 'some/module'
       // ...
-      // const instance = moduleImport()
-      //       ^^^ true for this reference to 'some/module'
+      // returns { importModuleName: 'some/module', importName: 'moduleImport' }
+      // if the importModuleName and importName are configured options in the
+      // effectDisallowedDependenciesMap. Otherwise returns undefined.
       function isDisallowedDependency(resolved) {
         if (!isArray(resolved.defs)) {
-          return false;
+          return undefined;
         }
 
         const def = resolved.defs[0];
         if (def == null) {
-          return false;
+          return undefined;
         }
 
         if (def.node.type !== 'VariableDeclarator') {
-          return false;
+          return undefined;
         }
 
         const resolvedImportModule = resolveImportModuleForDef(

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -32,6 +32,39 @@ export default {
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
           },
+          effectDisallowedDependencies: {
+            type: 'array',
+            minItems: 1,
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['module', 'imports'],
+              properties: {
+                module: {
+                  type: 'string',
+                },
+                imports: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['name', 'fields'],
+                    properties: {
+                      name: {
+                        type: 'string',
+                      },
+                      fields: {
+                        type: 'array',
+                        items: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       },
     ],
@@ -51,9 +84,23 @@ export default {
         context.options[0].enableDangerousAutofixThisMayCauseInfiniteLoops) ||
       false;
 
+    const effectDisallowedDependencies =
+      (context.options &&
+        context.options[0] &&
+        context.options[0].effectDisallowedDependencies) ||
+      [];
+
+    const effectDisallowedDependenciesMap = new Map(
+      effectDisallowedDependencies.map(({module, imports}) => [
+        module,
+        imports,
+      ]),
+    );
+
     const options = {
       additionalHooks,
       enableDangerousAutofixThisMayCauseInfiniteLoops,
+      effectDisallowedDependenciesMap,
     };
 
     function reportProblem(problem) {
@@ -148,6 +195,43 @@ export default {
 
       const isArray = Array.isArray;
 
+      // Disallowed dependencies are specified in the eslint rule config
+      // import { moduleImport } from 'some/module'
+      // ...
+      // const instance = moduleImport()
+      //       ^^^ true for this reference to 'some/module'
+      function isDisallowedDependency(resolved) {
+        if (!isArray(resolved.defs)) {
+          return false;
+        }
+
+        const def = resolved.defs[0];
+        if (def == null) {
+          return false;
+        }
+
+        if (def.node.type !== 'VariableDeclarator') {
+          return false;
+        }
+
+        const resolvedImportModule = resolveImportModuleForDef(
+          componentScope,
+          def.node,
+        );
+        if (resolvedImportModule) {
+          const {importModuleName, importName} = resolvedImportModule;
+          let foundDependency = undefined;
+          const moduleImports =
+            options.effectDisallowedDependenciesMap.get(importModuleName);
+          if (moduleImports) {
+            // Find the import name and disallowed fields for this module
+            foundDependency = moduleImports.find(
+              moduleImport => moduleImport.name === importName,
+            );
+          }
+          return foundDependency;
+        }
+      }
       // Next we'll define a few helpers that helps us
       // tell if some values don't have to be declared as deps.
 
@@ -458,7 +542,25 @@ export default {
             const isStable =
               memoizedIsStableKnownHookValue(resolved) ||
               memoizedIsFunctionWithoutCapturedValues(resolved);
+
+            const foundDisallowedDependency = isDisallowedDependency(resolved);
+
+            let exemptedProperty = true;
+            if (
+              foundDisallowedDependency &&
+              dependencyNode.type === 'MemberExpression'
+            ) {
+              if (
+                !foundDisallowedDependency.fields.includes(
+                  dependencyNode.property.name,
+                )
+              ) {
+                exemptedProperty = false;
+              }
+            }
             dependencies.set(dependency, {
+              isConfigExemptDependency:
+                exemptedProperty && foundDisallowedDependency,
               isStable,
               references: [reference],
             });
@@ -1341,14 +1443,19 @@ function collectRecommendations({
     };
   }
 
+  const exemptDependencies = new Set();
   // Mark all required nodes first.
   // Imagine exclamation marks next to each used deep property.
-  dependencies.forEach((_, key) => {
+  dependencies.forEach(({isConfigExemptDependency}, key) => {
     const node = getOrCreateNodeByPath(depTree, key);
     node.isUsed = true;
     markAllParentsByPath(depTree, key, parent => {
       parent.isSubtreeUsed = true;
     });
+    if (isConfigExemptDependency) {
+      node.isConfigExemptDependency = true;
+      exemptDependencies.add(key);
+    }
   });
 
   // Mark all satisfied nodes.
@@ -1411,7 +1518,7 @@ function collectRecommendations({
         // `props.foo` is enough if you read `props.foo.id`.
         return;
       }
-      if (child.isUsed) {
+      if (child.isUsed && !child.isConfigExemptDependency) {
         // Remember that no declared deps satisfied this node.
         missingPaths.add(path);
         // If we got here, nothing in its subtree was satisfied.
@@ -1426,14 +1533,13 @@ function collectRecommendations({
       );
     });
   }
-
   // Collect suggestions in the order they were originally specified.
   const suggestedDependencies = [];
   const unnecessaryDependencies = new Set();
   const duplicateDependencies = new Set();
   declaredDependencies.forEach(({key}) => {
     // Does this declared dep satisfy a real need?
-    if (satisfyingDependencies.has(key)) {
+    if (satisfyingDependencies.has(key) && !exemptDependencies.has(key)) {
       if (suggestedDependencies.indexOf(key) === -1) {
         // Good one.
         suggestedDependencies.push(key);
@@ -1445,7 +1551,8 @@ function collectRecommendations({
       if (
         isEffect &&
         !key.endsWith('.current') &&
-        !externalDependencies.has(key)
+        !externalDependencies.has(key) &&
+        !exemptDependencies.has(key)
       ) {
         // Effects are allowed extra "unnecessary" deps.
         // Such as resetting scroll when ID changes.
@@ -1472,6 +1579,63 @@ function collectRecommendations({
     duplicateDependencies,
     missingDependencies,
   };
+}
+
+function resolveImportModuleForDef(scope, node) {
+  let init = node.init;
+  if (init == null) {
+    return null;
+  }
+
+  while (init.type === 'TSAsExpression') {
+    init = init.expression;
+  }
+  // Detect primitive constants
+  // const foo = 42
+  let declaration = node.parent;
+  if (declaration == null) {
+    // This might happen if variable is declared after the callback.
+    // In that case ESLint won't set up .parent refs.
+    // So we'll set them up manually.
+    fastFindReferenceWithParent(scope.block, node.id);
+    declaration = node.parent;
+    if (declaration == null) {
+      return null;
+    }
+  }
+
+  if (init.type !== 'CallExpression') {
+    return null;
+  }
+  const callee = init.callee;
+  if (callee.type !== 'Identifier') {
+    return null;
+  }
+  const id = node.id;
+  const {name} = callee;
+  if (id.type === 'Identifier') {
+    const moduleImport = scope.references.find(ref => {
+      if (!isSameIdentifier(ref.identifier, callee)) {
+        return false;
+      }
+      if (!ref.resolved || !ref.resolved.defs || !ref.resolved.defs[0]) {
+        return false;
+      }
+      return ref.resolved.defs[0].type === 'ImportBinding';
+    });
+
+    if (!moduleImport) {
+      return false;
+    }
+    const moduleImportSource = moduleImport.resolved.defs[0];
+    if (moduleImportSource.parent.type === 'ImportDeclaration') {
+      return {
+        importModuleName: moduleImportSource.parent.source.value,
+        importName: name,
+      };
+    }
+  }
+  return null;
 }
 
 // If the node will result in constructing a referentially unique value, return


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This PR adds option `effectDisallowedDependencies` to the `react-hooks/exhaustive-deps` eslint rule.

The `effectDisallowedDependencies` specifies an array of imports that should not be added to the effect dependencies array. Each item in the array contains a `module` and `imports` field.

- `module`: The source identifier of the module for example: `'some/module'` in the import declaration `import { someImport } from 'some/module'`. 

- `imports`:  Is an array of items that include `name` and `fields` properties.

More on `imports`:

- `name`: the imported property. For example `someImport` in the import declaration `import { someImport } from 'some/module'`. `someImport` can not be included in the dependencies array.

- `fields`: the list of fields of imported `name` property that should not be included in the dependencies array. For example, if `fields` includes `fieldOne` and `name` is `someImport`, then `someImport.fieldOne` cannot be included in the dependencies array. 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I added tests cases to the existing test suite in  https://github.com/facebook/react/blob/47b6a05a146a92033d41f5dc3c20bd2987519193/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js#L1-L8534

The added tests are on this PR.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
